### PR TITLE
Ensure tunnel `Out` unrendered when `In` unmounts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,10 @@ export default function tunnel() {
   return {
     In: ({ children }: Props) => {
       const set = useStore((state) => state.set)
-      useLayoutEffect(() => void set({ current: children }), [children])
+      useLayoutEffect(() => {
+        set({ current: children })
+        return () => void set({ current: null })
+      }, [children])
       return null
     },
     Out: () => {


### PR DESCRIPTION
I noticed that when `<Tunnel.In>` is unrendered it doesn't clean up `<Tunnel.Out>`. This adds a return statement to the `useLayoutEffect` to clear out the children on unmount. 