### PR TITLE
Fix types for `Out` to make it callable in JSX

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export default function tunnel() {
     },
     Out: () => {
       const current = useStore((state) => state.current)
-      return current
+      return current as React.ReactElement | null
     },
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3087225/158705856-28a503f6-2b5c-450d-ba6b-1d48f93e0244.png)

I hit upon an issue where the types for `Out` cause it to be a type error when you try to include it in a component. I think this is primarily because `ReactNode` includes `undefined` but that's not a valid `Element` type. 

I'm not certain that `ReactElement | null` is the most _exact_ type for what we expect here, but it broadly does cover a narrower range of `ReactNode` that could be expected to return from `Out`
