### PR TITLE
Replaced useLayoutEffect with useEffect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react'
+import React, { useEffect } from 'react'
 import create, { SetState } from 'zustand'
 
 type Props = { children: React.ReactNode }
@@ -14,7 +14,7 @@ export default function tunnel() {
   return {
     In: ({ children }: Props) => {
       const set = useStore((state) => state.set)
-      useLayoutEffect(() => {
+      useEffect(() => {
         set({ current: children })
         return () => void set({ current: null })
       }, [children])


### PR DESCRIPTION
useLayoutEffect bloating logs with the following error:

```
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
    at In (C:\web\app\node_modules\tunnel-rat\dist\index.cjs.js:17:7)
    at Suspense
    at div
    at C:\web\app\node_modules\@emotion\react\dist\emotion-element-ae8cc4ba.cjs.dev.js:71:25
```