### PR TITLE
fix: bump zustand and stop using default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
   },
   "homepage": "https://github.com/pmndrs/tunnel-rat#readme",
   "dependencies": {
-    "zustand": "^4.1.0"
+    "zustand": "^4.3.2"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useLayoutEffect } from 'react'
-import create, { StoreApi } from 'zustand'
+import { create, StoreApi } from 'zustand'
 
 type Props = { children: React.ReactNode }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8496,9 +8496,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zustand@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.1.0.tgz#9676eeb30ece318707fd739a96dcb7b410d7d2c2"
-  integrity sha512-ba39yDM90wFHiCO5AuoP2Tr1vSY5Eggduk0ou91mWL/qKnz2sBq8AcdFoticOftt7AfIHRBENI7WfjkUrqB3vA==
+zustand@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.2.tgz#bb121fcad84c5a569e94bd1a2695e1a93ba85d39"
+  integrity sha512-rd4haDmlwMTVWVqwvgy00ny8rtti/klRoZjFbL/MAcDnmD5qSw/RZc+Vddstdv90M5Lv6RPgWvm1Hivyn0QgJw==
   dependencies:
     use-sync-external-store "1.2.0"


### PR DESCRIPTION
Installing `tunnel-rat` installs it with latest zustand which then complains of using the default export, which gets a bit annoying since we're already tunneling at [excalidraw](https://github.com/excalidraw/excalidraw/) ❤️