### PR TITLE
Remove zustand dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,8 @@
     "ts-jest": "^28.0.8",
     "typescript": "^4.4.4"
   },
+  "peerDependencies": {
+    "react": ">=18.0.0"
+  },
   "homepage": "https://github.com/pmndrs/tunnel-rat#readme"
 }

--- a/package.json
+++ b/package.json
@@ -81,8 +81,5 @@
     "ts-jest": "^28.0.8",
     "typescript": "^4.4.4"
   },
-  "homepage": "https://github.com/pmndrs/tunnel-rat#readme",
-  "dependencies": {
-    "zustand": "^4.3.2"
-  }
+  "homepage": "https://github.com/pmndrs/tunnel-rat#readme"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,70 +3,65 @@ import { useIsomorphicLayoutEffect } from './utils'
 
 type Props = { children: React.ReactNode }
 
-export default function tunnel() {
-  let rats: Array<React.ReactNode> = []
-  const ratNotifiers: Array<() => void> = []
-  function subscribeToRatChanges(onRatsChange: () => void) {
-    ratNotifiers.push(onRatsChange)
+function createStore<TState>(initialState: TState) {
+  let state: TState = initialState
+  const notifiers: Array<() => void> = []
+
+  function subscribe(onChange: () => void) {
+    notifiers.push(onChange)
     return () => {
-      ratNotifiers.splice(ratNotifiers.indexOf(onRatsChange), 1)
-    }
-  }
-  function getRats() {
-    return rats
-  }
-  function setRats(newRats: Array<React.ReactNode>) {
-    rats = newRats
-    for (const notify of ratNotifiers) {
-      notify()
+      notifiers.splice(notifiers.indexOf(onChange), 1)
     }
   }
 
-  let version = 0
-  const versionNotifiers: Array<() => void> = []
-  function subscribeToVersionChanges(onVersionChange: () => void) {
-    versionNotifiers.push(onVersionChange)
-    return () => {
-      versionNotifiers.splice(versionNotifiers.indexOf(onVersionChange), 1)
-    }
-  }
-  function getVersion() {
-    return version
-  }
-  function setVersion(newVersion: number) {
-    version = newVersion
-    for (const notify of versionNotifiers) {
-      notify()
-    }
+  function getState() {
+    return state
   }
 
   return {
+    useState() {
+      return useSyncExternalStore(subscribe, getState)
+    },
+    setState(updateState: (currentState: TState) => TState) {
+      state = updateState(state)
+      for (const notify of notifiers) {
+        notify()
+      }
+    },
+  }
+}
+
+export default function tunnel() {
+  const ratsStore = createStore<Array<React.ReactNode>>([])
+  const versionStore = createStore(0)
+
+  return {
     In: ({ children }: Props) => {
-      const currentVersion = useSyncExternalStore(subscribeToVersionChanges, getVersion)
+      const version = versionStore.useState()
 
       /* When this component mounts, we increase the version number.
       This will cause all existing rats to re-render (just like if the Out component
       were mapping items to a list.) The re-rendering will cause the final
       order of rendered components to match what the user is expecting. */
       useIsomorphicLayoutEffect(() => {
-        setVersion(version + 1)
+        versionStore.setState((currentVersion) => currentVersion + 1)
       }, [])
 
       /* Any time the children _or_ the version number change, insert
       the specified React children into the list of rats. */
       useIsomorphicLayoutEffect(() => {
-        setRats([...rats, children])
+        ratsStore.setState((rats) => [...rats, children])
         return () => {
-          setRats(rats.filter((child) => child !== children))
+          ratsStore.setState((rats) => rats.filter((child) => child !== children))
         }
-      }, [children, currentVersion])
+      }, [children, version])
 
       return null
     },
 
     Out: () => {
-      const children = useSyncExternalStore(subscribeToRatChanges, getRats)
-      return <>{children}</>
+      const rats = ratsStore.useState()
+      return <>{rats}</>
     },
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8145,11 +8145,6 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-sync-external-store@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
-  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
-
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -8495,10 +8490,3 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-zustand@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.2.tgz#bb121fcad84c5a569e94bd1a2695e1a93ba85d39"
-  integrity sha512-rd4haDmlwMTVWVqwvgy00ny8rtti/klRoZjFbL/MAcDnmD5qSw/RZc+Vddstdv90M5Lv6RPgWvm1Hivyn0QgJw==
-  dependencies:
-    use-sync-external-store "1.2.0"


### PR DESCRIPTION
This replaces the use of `zustand` with an inline implementation of the same functionality using `useSyncExternalStore` directly. This approximates what zustand was doing.

With this change, this package has zero non-dev dependencies.

This addresses a handful of open issues:
- https://github.com/pmndrs/tunnel-rat/issues/16
- https://github.com/pmndrs/tunnel-rat/issues/19
- https://github.com/pmndrs/tunnel-rat/issues/21
- https://github.com/pmndrs/tunnel-rat/issues/24

All tests are currently passing but let me know if there is any more cleanup I should do here.